### PR TITLE
Mharvan/export fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,21 @@ is `merged`, `replaced`, `ignored`, `deleted`, or `upserted`.
 
 
 ```TypeScript
-import { ComplexRules, UpdateAction, Updater } from "object_updater";
+import { ComplexRules, UpdateAction, updateObject } from "object_updater";
+
+
+interface User {
+    id: number;
+    name: string;
+    [index: string]: unknown;
+}
+
+interface Person {
+    name: string;
+    age: number;
+    tags: string[];
+    users: User[];
+}
 
 const original = {
     name: "Alice",
@@ -80,7 +94,7 @@ const update = {
     ]
 };
 
-const rules: Record<string, PrimitiveRule> = {
+const rules: ComplexRules<Person> = {
     name: { action: UpdateAction.REPLACE },  // Replace `name`
     age: { action: UpdateAction.IGNORE },    // Ignore `age`
     tags: { action: UpdateAction.UNION },    // Merge `tags`, removing duplicates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object_updater",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generic object updater with rules",
   "main": "compiled/main.js",
   "module": "compiled/main.js",
@@ -8,7 +8,9 @@
   "keywords": [
     "object",
     "update",
-    "rules"
+    "rules",
+    "merge",
+    "recursive"
   ],
   "files": [
     "compiled"

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,5 +5,9 @@
 import { ComplexRules, UpdateAction } from "./interfaces";
 import { Updater } from "./updater";
 
+
+const updater: Updater = new Updater();
+const updateObject = updater.updateObject.bind(updater);
+
 /** @public */
-export { Updater, ComplexRules, UpdateAction };
+export { updateObject, ComplexRules, UpdateAction };


### PR DESCRIPTION
Export for `updateObject` function was added, now there is no more need to create new Updater class everytime when updater should be used. 
ReadMe file examples were updated accordingly. 
Package version was increased. 